### PR TITLE
fix: remove command check in subcommand

### DIFF
--- a/aipy.py
+++ b/aipy.py
@@ -87,14 +87,12 @@ def shell_run(
         kwargs = {
             "args": cmd_system,
             "shell": True,
-            "check": True,
         }
         if capture_output:
             kwargs.update(
                 {
                     "text": True,
                     "capture_output": capture_output,
-                    "check": False,
                 }
             )
         return subprocess.run(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aipy"
-version = "2.13.1"
+version = "2.13.2"
 description = "ollama's support tools"
 authors = [{ name = "Douglas Panhota", email = "douglaspands@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Foi removido o argumento `check`, onde é capturado o resultado de erro da execução e é emitido uma exceção com ele.